### PR TITLE
OADP-639: Add custom CA field for restic.

### DIFF
--- a/internal/backup/volumesnapshotcontent_action.go
+++ b/internal/backup/volumesnapshotcontent_action.go
@@ -96,6 +96,12 @@ func (p *VolumeSnapshotContentBackupItemAction) Execute(item runtime.Unstructure
 			return nil, nil, errors.WithStack(err)
 		}
 
+		// get custom CA secret name for restic
+		resticCustomCASecretName, err := util.GetResticCustomCASecretName(backup, backup.Namespace, p.Log)
+		if err != nil {
+			return nil, nil, errors.WithStack(err)
+		}
+
 		// craft a VolumeBackupSnapshot object to be created
 		vsb := datamoverv1alpha1.VolumeSnapshotBackup{
 			ObjectMeta: metav1.ObjectMeta{
@@ -114,6 +120,12 @@ func (p *VolumeSnapshotContentBackupItemAction) Execute(item runtime.Unstructure
 					Name: resticSecretName,
 				},
 			},
+		}
+
+		if resticCustomCASecretName != "" {
+			vsb.Spec.ResticCustomCASecretRef = corev1api.LocalObjectReference{
+				Name: resticCustomCASecretName,
+			}
 		}
 
 		// check if VolumeBackupSnapshot CR exists for VSC

--- a/internal/restore/volumesnapshotrestore_action.go
+++ b/internal/restore/volumesnapshotrestore_action.go
@@ -71,6 +71,12 @@ func (p *VolumeSnapshotRestoreRestoreItemAction) Execute(input *velero.RestoreIt
 		},
 	}
 
+	if vsb.Spec.ResticCustomCASecretRef != "" {
+		vsr.Spec.ResticCustomCASecretRef = corev1api.LocalObjectReference{
+			Name: vsb.Spec.ResticCustomCASecretRef,
+		}
+	}
+
 	// if namespace mapping is specified
 	if val, ok := input.Restore.Spec.NamespaceMapping[vsr.GetNamespace()]; ok {
 		vsr.SetNamespace(val)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -486,6 +486,24 @@ func GetDataMoverCredName(backup *velerov1api.Backup, protectedNS string, log lo
 	return resticSecretName, nil
 }
 
+func GetResticCustomCASecretName(backup *velerov1api.Backup, protectedNS string, log logrus.FieldLogger) (string, error) {
+
+	bslName := backup.Spec.StorageLocation
+	resticCustomCAName := fmt.Sprintf("%v-volsync-restic-customca", bslName)
+
+	secretClient, _, err := GetClients()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	// check this secret exists
+	if _, err := secretClient.CoreV1().Secrets(protectedNS).Get(context.TODO(), resticCustomCAName, metav1.GetOptions{}); err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return resticCustomCAName, nil
+}
+
 func CheckIfVolumeSnapshotRestoresAreComplete(ctx context.Context, volumesnapshotrestores datamoverv1alpha1.VolumeSnapshotRestoreList, log logrus.FieldLogger) error {
 	eg, _ := errgroup.WithContext(ctx)
 	timeoutValue := "10m"


### PR DESCRIPTION
Depends on https://github.com/migtools/volume-snapshot-mover/pull/198 for types update, unless there's a better way to do this than adding type fields.