### PR TITLE
OADP-1151: Delete Volsync ReplicationSource CRs once the backup deletion is triggered

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vmware-tanzu/velero-plugin-for-csi
 go 1.17
 
 require (
+	github.com/backube/volsync v0.7.0
 	github.com/konveyor/volume-snapshot-mover v0.0.0-20230320194735-4a6daa0fa73f
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -31,9 +31,12 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/backube/volsync v0.7.0 h1:7sDZk3MvJVhcUwCylX0dwYcmQrxyEhZ6sIjFJ4DFF94=
+github.com/backube/volsync v0.7.0/go.mod h1:Icl6Ipn3RCOebGf5ZauipYbqtQCwdC75Hq0iaSpJBf8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/internal/util/labels_annotations.go
+++ b/internal/util/labels_annotations.go
@@ -54,4 +54,5 @@ const (
 	RestoreNameLabel           = "velero.io/restore-name"
 	PersistentVolumeClaimLabel = "velero.io/persistent-volume-claim-name"
 	VolumeSnapshotBackupLabel  = "velero.io/vsb-name"
+	VSBLabel                   = "datamover.oadp.openshift.io/vsb"
 )


### PR DESCRIPTION
Related VSM controller PR: https://github.com/migtools/volume-snapshot-mover/pull/219

Images you can use for testing:
```
dataMoverImageFqin: 'quay.io/spampatt/volume-snapshot-mover:keep-rs'
vsmPluginImageFqin: 'quay.io/spampatt/velero-plugin-for-vsm:dia-rs'
```