### PR TITLE
OADP-2067: Run VSM VSB plugins only for a specified backup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # The binary to build (just the basename).
 BIN ?= velero-plugin-for-vsm
 
-BUILD_IMAGE ?= golang:1.17-stretch
+BUILD_IMAGE ?= golang:1.20-bullseye
 
 REGISTRY ?= velero
 IMAGE_NAME ?= $(REGISTRY)/velero-plugin-for-vsm

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/velero-plugin-for-csi
 
-go 1.17
+go 1.20
 
 require (
 	github.com/backube/volsync v0.7.0

--- a/internal/backup/volumesnapshotbackup_action.go
+++ b/internal/backup/volumesnapshotbackup_action.go
@@ -36,6 +36,14 @@ func (p *VolumeSnapshotBackupBackupItemAction) Execute(item runtime.Unstructured
 	}
 	p.Log.Infof("Converted Item to VSB: %v", vsb)
 
+	// check the VSB has the same backup name from label as the current backup
+	isVSBForCurrentBackup := util.VSBBelongsToBackup(backup.Name, &vsb, p.Log)
+
+	if !isVSBForCurrentBackup {
+		p.Log.Infof("unrelated volumesnapshotbackup found %s, skipping datamover backup for this VSB", vsb.Name)
+		return item, nil, nil
+	}
+
 	vsbNew, err := util.GetVolumeSnapshotbackupWithStatusData(vsb.Namespace, vsb.Name, p.Log)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)

--- a/internal/backup/volumesnapshotcontent_action.go
+++ b/internal/backup/volumesnapshotcontent_action.go
@@ -70,12 +70,12 @@ func (p *VolumeSnapshotContentBackupItemActionV2) Execute(item runtime.Unstructu
 	if util.DataMoverCase() {
 
 		// check the VSC has the same backup name from label as the current backup
-		isVSForCurrentBackup := util.VSBHasVSBackupName(backup, &snapCont, p.Log)
+		isVSCForCurrentBackup := util.VSCBelongsToBackup(backup, &snapCont, p.Log)
 
-		if !isVSForCurrentBackup {
-			p.Log.Warnf("stale volumesnapshot found %s", snapCont.Spec.VolumeSnapshotRef.Name)
+		if !isVSCForCurrentBackup {
+			p.Log.Infof("unrelated volumesnapshotcontent found %s, skipping VSB creation", snapCont.Spec.VolumeSnapshotRef.Name)
 
-			return nil, nil, "", nil, nil
+			return item, nil, "", nil, nil
 		}
 
 		_, snapshotClient, err := util.GetClients()

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -610,13 +610,26 @@ func WaitForDataMoverRestoreToComplete(restoreName string, log logrus.FieldLogge
 	return nil
 }
 
-func VSBHasVSBackupName(backup *velerov1api.Backup, snapCont *snapshotv1api.VolumeSnapshotContent, log logrus.FieldLogger) bool {
+func VSCBelongsToBackup(backup *velerov1api.Backup, snapCont *snapshotv1api.VolumeSnapshotContent, log logrus.FieldLogger) bool {
 
 	// compare backup name on label with current backup name
 	VSCBackupName := snapCont.Labels[BackupNameLabel]
 	currentBackupName := backup.Name
 
 	if VSCBackupName != currentBackupName {
+		return false
+	}
+
+	return true
+}
+
+func VSBBelongsToBackup(backupName string, vsb *datamoverv1alpha1.VolumeSnapshotBackup, log logrus.FieldLogger) bool {
+
+	// compare backup name on label with current backup name
+	VSBBackupName := vsb.Labels[BackupNameLabel]
+	currentBackupName := backupName
+
+	if VSBBackupName != currentBackupName {
 		return false
 	}
 


### PR DESCRIPTION
Fixes https://github.com/migtools/volume-snapshot-mover/issues/233

Also fix VSC backup plugin bug -- return item if not returning error. Also rename vsb restore plugin to reflect the resource type involved.