### PR TITLE
Revert "add APP_ROOT to Dockerfile since it's gone from builder...(#20)"

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,4 @@
 FROM quay.io/konveyor/builder:latest AS builder
-ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 COPY . $APP_ROOT/src/velero-plugin-for-vsm
 WORKDIR $APP_ROOT/src/velero-plugin-for-vsm


### PR DESCRIPTION
no longer needed since builder image was fixed.

This reverts commit defb921aa632be03dbf9afcab5783a55f6a492c0.