### PR TITLE
Add github action for the unittest to the velero-plugin-for-vsm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Velero-plugin-for-vsm - '$ make test' target
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ '1.20' ]
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Setup Go Environment ${{ matrix.go-version }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Go Version check
+        run: go version
+
+      - name: Install Go dependencies
+        run: go get .
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Run Tests
+        run: go test -timeout 30s -v -cover ./...


### PR DESCRIPTION
Use github action for the unit tests for velero-plugin-for-vsm plugin.

This project is within migtools where Github actions are allowed and as such it's easy to run go test is used.

We do not want to run make test as this project does not have all the Makefile deps and folders for building it.

We need to use go 1.20+, because this project has such version specified in the `go.mod` file.